### PR TITLE
Add loading skeleton and parallel initial data loading

### DIFF
--- a/lib/screens/defect_tracker_screen.dart
+++ b/lib/screens/defect_tracker_screen.dart
@@ -4,6 +4,7 @@ import '../models/defect.dart';
 import '../models/claim.dart';
 import '../models/project.dart';
 import '../services/database_service.dart';
+import '../widgets/loading_skeleton.dart';
 
 class DefectTrackerScreen extends StatefulWidget {
   const DefectTrackerScreen({super.key});
@@ -44,14 +45,17 @@ class _DefectTrackerScreenState extends State<DefectTrackerScreen> {
   // Загрузка начальных данных
   Future<void> loadInitialData() async {
     setState(() => isLoading = true);
-    
+
     try {
-      // Загружаем проекты
-      projects = await DatabaseService.getProjects();
-      
-      // Загружаем типы дефектов и статусы
-      defectTypes = await DatabaseService.getDefectTypes();
-      defectStatuses = await DatabaseService.getDefectStatuses();
+      final results = await Future.wait([
+        DatabaseService.getProjects(),
+        DatabaseService.getDefectTypes(),
+        DatabaseService.getDefectStatuses(),
+      ]);
+
+      projects = results[0] as List<Project>;
+      defectTypes = results[1] as List<DefectType>;
+      defectStatuses = results[2] as List<DefectStatus>;
       
       if (projects.isNotEmpty) {
         selectedProject = projects.first;
@@ -304,11 +308,7 @@ class _DefectTrackerScreenState extends State<DefectTrackerScreen> {
   @override
   Widget build(BuildContext context) {
     if (isLoading) {
-      return const Scaffold(
-        body: Center(
-          child: CircularProgressIndicator(),
-        ),
-      );
+      return const LoadingSkeleton();
     }
 
     if (selectedProject == null) {

--- a/lib/widgets/loading_skeleton.dart
+++ b/lib/widgets/loading_skeleton.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/material.dart';
+
+class LoadingSkeleton extends StatelessWidget {
+  const LoadingSkeleton({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: SafeArea(
+        child: ListView.builder(
+          padding: const EdgeInsets.all(16),
+          itemCount: 8,
+          itemBuilder: (context, index) => Padding(
+            padding: const EdgeInsets.symmetric(vertical: 8),
+            child: Container(
+              height: 20,
+              decoration: BoxDecoration(
+                color: Colors.grey.shade300,
+                borderRadius: BorderRadius.circular(8),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- speed up initial data fetch by loading projects and defect configs in parallel
- show skeleton placeholders while data loads

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6873e7c5079c832e9fac4c9a57bda2f3